### PR TITLE
Open target URLs not in PWA but in default browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/Jhon-Crow/trovu/issues/1
-Your prepared branch: issue-1-cc20e062a666
-Your prepared working directory: /tmp/gh-issue-solver-1771010490493
-Your forked repository: konard/Jhon-Crow-trovu
-Original repository (upstream): Jhon-Crow/trovu
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/Jhon-Crow/trovu/issues/1
+Your prepared branch: issue-1-cc20e062a666
+Your prepared working directory: /tmp/gh-issue-solver-1771010490493
+Your forked repository: konard/Jhon-Crow-trovu
+Original repository (upstream): Jhon-Crow/trovu
+
+Proceed.

--- a/src/ts/modules/CallHandler.ts
+++ b/src/ts/modules/CallHandler.ts
@@ -43,7 +43,7 @@ export default class CallHandler {
       return;
     }
 
-    window.location.replace(redirectUrl);
+    Env.navigateTo(redirectUrl, env.isRunningStandalone());
   }
 
   /**

--- a/src/ts/modules/Env.test.ts
+++ b/src/ts/modules/Env.test.ts
@@ -99,4 +99,30 @@ describe("Env", () => {
       reload: true,
     });
   });
+
+  describe("isExternalUrl", () => {
+    beforeAll(() => {
+      // Mock window.location.origin
+      Object.defineProperty(window, "location", {
+        value: { origin: "https://trovu.net" },
+        writable: true,
+      });
+    });
+
+    test("returns true for external URLs", () => {
+      expect(Env.isExternalUrl("https://google.com")).toBe(true);
+      expect(Env.isExternalUrl("https://www.youtube.com/watch?v=123")).toBe(true);
+      expect(Env.isExternalUrl("https://maps.google.com")).toBe(true);
+    });
+
+    test("returns false for internal URLs", () => {
+      expect(Env.isExternalUrl("https://trovu.net/process/index.html")).toBe(false);
+      expect(Env.isExternalUrl("/process/index.html")).toBe(false);
+      expect(Env.isExternalUrl("../index.html")).toBe(false);
+    });
+
+    test("returns false for invalid URLs", () => {
+      expect(Env.isExternalUrl("")).toBe(false);
+    });
+  });
 });

--- a/src/ts/modules/Env.ts
+++ b/src/ts/modules/Env.ts
@@ -455,4 +455,34 @@ export default class Env {
   isRunningStandalone() {
     return window.navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
   }
+
+  /**
+   * Check if a URL is external (different origin from the current page).
+   *
+   * @param {string} url - The URL to check.
+   * @returns {boolean} - True if the URL is external.
+   */
+  static isExternalUrl(url) {
+    try {
+      const urlObj = new URL(url, window.location.origin);
+      return urlObj.origin !== window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Navigate to a URL, opening external URLs in the default browser when running as PWA.
+   *
+   * @param {string} url - The URL to navigate to.
+   * @param {boolean} isStandalone - Whether the app is running in standalone (PWA) mode.
+   */
+  static navigateTo(url, isStandalone) {
+    if (isStandalone && Env.isExternalUrl(url)) {
+      // Open external URLs in default browser when running as PWA
+      window.open(url, "_blank");
+    } else {
+      window.location.replace(url);
+    }
+  }
 }

--- a/src/ts/modules/Home.ts
+++ b/src/ts/modules/Home.ts
@@ -253,7 +253,7 @@ export default class Home {
     } else {
       redirectUrl = CallHandler.getRedirectUrlToHome(envQuery, response);
     }
-    window.location.href = redirectUrl;
+    Env.navigateTo(redirectUrl, this.env.isRunningStandalone());
   };
 
   /**


### PR DESCRIPTION
## Summary

When running Trovu as a PWA (standalone mode), external URLs are now opened in the device's default browser instead of within the PWA window.

This enables:
- Better integration with device browsers (Chrome, Firefox, Safari, etc.)
- Proper handling of app-linked URLs (e.g., YouTube, Google Maps apps)
- Native browser features for external sites

## Implementation Details

- **`Env.isExternalUrl(url)`**: New static method that checks if a URL is external (different origin from the current page)
- **`Env.navigateTo(url, isStandalone)`**: New static method that handles navigation with PWA awareness:
  - If running in standalone mode and URL is external: opens in default browser via `window.open(url, "_blank")`
  - Otherwise: uses standard `window.location.replace(url)`
- **CallHandler.ts**: Updated to use `Env.navigateTo()` for redirects
- **Home.ts**: Updated to use `Env.navigateTo()` for query submission redirects

## Technical Notes

The solution uses `window.open(url, "_blank")` which:
- On desktop PWAs: Opens in the system browser
- On mobile: Behavior varies by platform, but generally opens in an in-app browser with option to open in full browser

This is the most widely supported approach according to web.dev and MDN documentation.

## Test Plan

- [x] Unit tests pass (`npm run test-unit`)
- [x] Linting passes (`npm run lint-js`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual testing in PWA mode on desktop
- [ ] Manual testing in PWA mode on mobile

Fixes #1

---
🤖 Generated with [Claude Code](https://claude.ai/code)